### PR TITLE
 Bugfix: Wrong member list display, when no user on TS server

### DIFF
--- a/library.js
+++ b/library.js
@@ -58,7 +58,7 @@ Widget.renderTeamspeakWidget = function(widget, callback) {
                 console.log(err);
                 callback(null, '<h4>An Error occurred:<h4><pre>' + JSON.stringify(err, null, 2) + '</pre>')
 	})
-	
+
 	cl.on('error', function(err){
                 console.log(err);
                 callback(null, '<h4>An Error occurred:<h4><pre>' + JSON.stringify(err, null, 2) + '</pre>')
@@ -72,7 +72,7 @@ Widget.renderTeamspeakWidget = function(widget, callback) {
 				client_login_password: serverData.password
 			},
 			function(err, res){
-				if(err) { 
+				if(err) {
 					console.log(err);
 					callback(null, '<h4>An Error occurred:<h4><pre>' + JSON.stringify(err, null, 2) + '</pre>');
 					return
@@ -92,6 +92,7 @@ Widget.renderTeamspeakWidget = function(widget, callback) {
 							async.sortBy(rep.clients, function(x, callback) {
 							    callback(null, x.client_nickname);
 							}, function(err,result) {
+								cl.send('quit');
 							    rep.clients = result
 									var pre = ""+fs.readFileSync(path.resolve(__dirname,'./public/templates/teamspeak.tpl'));
 								  callback(null, templates.parse(pre, rep));

--- a/library.js
+++ b/library.js
@@ -89,7 +89,7 @@ Widget.renderTeamspeakWidget = function(widget, callback) {
 							callback(null, widget)
 					 	}
 						async.each(clients,function(client, callback){
-							if(client.client_type !== 1){
+							if(typeof client == 'object' && 'client_type' in client && client.client_type !== 1){
 								rep.clients.push(client)
 							}
 							callback()


### PR DESCRIPTION
I observe an issue with the widget, whenever there is no user logged in on the TS server. This is how it looks like:
![problem_ts_widget](https://user-images.githubusercontent.com/6916385/46579339-889b4f00-ca0f-11e8-882d-0fa9af489ad0.PNG)

I tracked down the problem to the clientlist not beeing empty, but also not showing the usual structure. The change I propose fixes this. Could you please merge it into your release?